### PR TITLE
Turn off dry run

### DIFF
--- a/.github/workflows/sync_yatm_issues.yml
+++ b/.github/workflows/sync_yatm_issues.yml
@@ -49,4 +49,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          ./yatm-v2/target/release/yatm_v2 github upload -c ${{ env.CONFIG_PATH }} -n
+          ./yatm-v2/target/release/yatm_v2 github upload -c ${{ env.CONFIG_PATH }}


### PR DESCRIPTION
Removed the '-n' flag from the YATM upload command.

This will turn on issue generation for lyrical