### PR TITLE
Add exclusion for 'rhel 10' and 'arm64' labels

### DIFF
--- a/config/lyrical/test_cases/tutorial_party.yaml
+++ b/config/lyrical/test_cases/tutorial_party.yaml
@@ -58,6 +58,10 @@ test_cases_builders:
           any_names: [Ignition]
           negate: false
       - !Exclude
+          all_labels: ['rhel 10', arm64]
+          # No arm64 on Windows
+          negate: false
+      - !Exclude
           all_labels: [windows, arm64]
           # No arm64 on Windows
           negate: false


### PR DESCRIPTION
Avoid more combinatorics with arm64 on RHEL 10